### PR TITLE
feat: add merchant and order models

### DIFF
--- a/src/models/Merchant.ts
+++ b/src/models/Merchant.ts
@@ -1,0 +1,22 @@
+import { DataTypes } from "sequelize";
+import sequelize from "../db/db.js";
+
+export const Merchant = sequelize.define("Merchant", {
+  id: {
+    type: DataTypes.UUID,
+    defaultValue: DataTypes.UUIDV4,
+    primaryKey: true,
+  },
+  name: {
+    type: DataTypes.TEXT,
+    allowNull: false,
+  },
+  shopify_id: {
+    type: DataTypes.TEXT,
+    allowNull: false,
+    unique: true,
+  },
+}, {
+  tableName: "merchants",
+  timestamps: true,
+});

--- a/src/models/Order.ts
+++ b/src/models/Order.ts
@@ -1,0 +1,26 @@
+import { DataTypes } from "sequelize";
+import sequelize from "../db/db.js";
+
+export const Order = sequelize.define("Order", {
+  id: {
+    type: DataTypes.UUID,
+    defaultValue: DataTypes.UUIDV4,
+    primaryKey: true,
+  },
+  shopify_order_id: {
+    type: DataTypes.TEXT,
+    allowNull: false,
+    unique: true,
+  },
+  total_price: {
+    type: DataTypes.DECIMAL,
+    allowNull: false,
+  },
+  created_at: {
+    type: DataTypes.DATE,
+    allowNull: false,
+  },
+}, {
+  tableName: "orders",
+  timestamps: false,
+});

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,0 +1,7 @@
+import { Merchant } from "./Merchant.js";
+import { Order } from "./Order.js";
+
+Merchant.hasMany(Order, { foreignKey: "merchant_id" });
+Order.belongsTo(Merchant, { foreignKey: "merchant_id" });
+
+export { Merchant, Order };


### PR DESCRIPTION
## Summary
- add Merchant model for merchants table
- add Order model for orders table
- define associations between Merchant and Order models

## Testing
- `npm run type-check`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689052e0c394832daca07fbeb51e4f1b