### PR TITLE
feat: add routing modules for API controllers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import morgan from "morgan";
 import dotenv from "dotenv";
 import { initializeDatabase, closeConnection } from "./db/db.js";
 import { startOrderSyncScheduler } from "./utils/scheduler.js";
+import routes from "./routes/index.routes.js";
 
 // Load environment variables
 dotenv.config();
@@ -66,8 +67,8 @@ app.get("/health", (_req, res) => {
   });
 });
 
-// API routes will be mounted here
-// TODO: Add route handlers for GMV endpoints
+// API routes
+app.use("/api", routes);
 
 // 404 handler
 app.use("*", (req, res) => {

--- a/src/routes/index.routes.ts
+++ b/src/routes/index.routes.ts
@@ -1,0 +1,27 @@
+import { Router } from "express";
+import keyRoutes from "./key.routes.js";
+import merchantRoutes from "./merchant.routes.js";
+import orderRoutes from "./order.routes.js";
+
+/**
+ * Aggregates all route modules and exposes a single router.
+ * Each sub-router handles endpoints for a specific resource.
+ */
+const router = Router();
+
+/**
+ * Routes for API key operations.
+ */
+router.use("/keys", keyRoutes);
+
+/**
+ * Routes for merchant operations.
+ */
+router.use("/merchants", merchantRoutes);
+
+/**
+ * Routes for order operations.
+ */
+router.use("/orders", orderRoutes);
+
+export default router;

--- a/src/routes/key.routes.ts
+++ b/src/routes/key.routes.ts
@@ -1,0 +1,16 @@
+import { Router } from "express";
+import { createKeyController } from "../controllers/key.controllers.js";
+
+/**
+ * Router handling API key related endpoints.
+ * Currently provides an endpoint to create merchant keys.
+ */
+const router = Router();
+
+/**
+ * POST /
+ * Creates a new API key for a merchant.
+ */
+router.post("/", createKeyController);
+
+export default router;

--- a/src/routes/merchant.routes.ts
+++ b/src/routes/merchant.routes.ts
@@ -1,0 +1,39 @@
+import { Router } from "express";
+import {
+  getAllMerchants,
+  getMerchantById,
+  getMerchantByShopifyId,
+  createMerchant,
+} from "../controllers/merchant.controllers.js";
+
+/**
+ * Router for merchant-related operations.
+ * Provides endpoints to retrieve and create merchants.
+ */
+const router = Router();
+
+/**
+ * GET /
+ * Returns a list of all merchants.
+ */
+router.get("/", getAllMerchants);
+
+/**
+ * GET /shopify/:shopifyId
+ * Returns a merchant by its Shopify ID.
+ */
+router.get("/shopify/:shopifyId", getMerchantByShopifyId);
+
+/**
+ * GET /:id
+ * Returns a merchant by database ID.
+ */
+router.get("/:id", getMerchantById);
+
+/**
+ * POST /
+ * Creates a new merchant.
+ */
+router.post("/", createMerchant);
+
+export default router;

--- a/src/routes/order.routes.ts
+++ b/src/routes/order.routes.ts
@@ -1,0 +1,46 @@
+import { Router } from "express";
+import {
+  getAllOrders,
+  getOrderById,
+  getOrderByShopifyOrderId,
+  getLastOrder,
+  createOrder,
+} from "../controllers/order.controllers.js";
+
+/**
+ * Router for order management operations.
+ * Exposes endpoints to query and create orders.
+ */
+const router = Router();
+
+/**
+ * GET /
+ * Returns a list of all orders.
+ */
+router.get("/", getAllOrders);
+
+/**
+ * GET /shopify/:shopifyOrderId
+ * Returns an order by its Shopify order ID.
+ */
+router.get("/shopify/:shopifyOrderId", getOrderByShopifyOrderId);
+
+/**
+ * GET /last
+ * Returns the most recently created order.
+ */
+router.get("/last", getLastOrder);
+
+/**
+ * GET /:id
+ * Returns an order by database ID.
+ */
+router.get("/:id", getOrderById);
+
+/**
+ * POST /
+ * Creates a new order.
+ */
+router.post("/", createOrder);
+
+export default router;


### PR DESCRIPTION
## Summary
- add `key.routes.ts`, `merchant.routes.ts`, and `order.routes.ts` with Express routes
- centralize routing via `index.routes.ts` and mount under `/api`

## Testing
- `npm run type-check`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689302bd75ac832d868176264cba928f